### PR TITLE
Use http.Client directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,3 @@ for _, addon := range addons {
   fmt.Println(addon.Name)
 }
 ```
-
-You can also provide a custom client:
-
-```go
-h := heroku.NewService(&HerokuClient{})
-```

--- a/schema/gen.go
+++ b/schema/gen.go
@@ -26,10 +26,8 @@ func (s *Schema) Generate() ([]byte, error) {
 
 	// TODO: Check if we need time.
 	templates.ExecuteTemplate(&buf, "imports.tmpl", []string{
-		"encoding/json", "fmt", "io", "log",
-		"net/http", "net/http/httputil", "strings",
-		"runtime", "time", "bytes", "reflect",
-		"code.google.com/p/go-uuid/uuid",
+		"encoding/json", "fmt", "io", "reflect",
+		"net/http", "runtime", "time", "bytes",
 	})
 	templates.ExecuteTemplate(&buf, "service.tmpl", struct {
 		Name    string

--- a/schema/templates/funcs.tmpl
+++ b/schema/templates/funcs.tmpl
@@ -7,19 +7,11 @@
       return s.Delete(fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}))
     {{else if eq .Rel "self"}}
       {{$Var := initialLow $Name}}var {{$Var}} {{initialCap $Name}}
-      return &{{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}))
+      return &{{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}), nil)
     {{else if eq .Rel "instances"}}
-      req, err := s.NewRequest("GET", fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}), nil)
-      if err != nil {
-        return nil, err
-      }
-
-      if lr != nil {
-        lr.SetHeader(req)
-      }
       {{$Var := printf "%s-%s" $Name "List" | initialLow}}
       var {{$Var}} []*{{initialCap $Name}}
-      return {{$Var}}, s.Client.Do(req, &{{$Var}})
+      return {{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}), lr)
     {{else if eq .Rel "empty"}}
       return s.{{methodCap .Method}}(fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}))
     {{else}}

--- a/schema/templates/service.tmpl
+++ b/schema/templates/service.tmpl
@@ -4,106 +4,24 @@ const (
 	DefaultUserAgent = "{{.Name}}/" + Version + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
 )
 
-// Client is the interface that wraps HTTP request creation
-// and execution.
-type Client interface {
-	Do(req *http.Request, v interface{}) error
-	NewRequest(method, path string, body interface{}) (*http.Request, error)
-}
-
 // Service represents your API.
 type Service struct {
-	Client Client
+	client *http.Client
 }
 
 // Create a Service using the given, if none is provided
-// it uses DefaultClient.
-func NewService(client Client) *Service {
-	if client == nil {
-		client = &DefaultClient{}
+// it uses http.DefaultClient.
+func NewService(c *http.Client) *Service {
+	if c == nil {
+		c = http.DefaultClient
 	}
 	return &Service{
-		Client: client,
+		client: c,
 	}
 }
 
 // Generates an HTTP request, but does not perform the request.
 func (s *Service) NewRequest(method, path string, body interface{}) (*http.Request, error) {
-	return s.Client.NewRequest(method, path, body)
-}
-
-// Sends a request and decodes the response into v.
-func (s *Service) Do(v interface{}, method, path string, body interface{}) error {
-	req, err := s.Client.NewRequest(method, path, body)
-	if err != nil {
-		return err
-	}
-	return s.Client.Do(req, v)
-}
-
-func (s *Service) Get(v interface{}, path string) error {
-	return s.Do(v, "GET", path, nil)
-}
-
-func (s *Service) Patch(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "PATCH", path, body)
-}
-
-func (s *Service) Post(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "POST", path, body)
-}
-
-func (s *Service) Put(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "PUT", path, body)
-}
-
-func (s *Service) Delete(path string) error {
-	return s.Do(nil, "DELETE", path, nil)
-}
-
-// DefaultClient implements Client interface.
-// DefaultClient has an internal HTTP client (HTTP) which defaults to http.DefaultClient.
-type DefaultClient struct {
-	// HTTP is the Client's internal http.Client, handling HTTP requests.
-	HTTP *http.Client
-
-	// The URL of the API to communicate with.
-	URL string
-
-	// Username is the HTTP basic auth username for API calls made by this Client.
-	Username string
-
-	// Password is the HTTP basic auth password for API calls made by this Client.
-	Password string
-
-	// UserAgent to be provided in API requests. Set to DefaultUserAgent if not
-	// specified.
-	UserAgent string
-
-	// Debug mode can be used to dump the full request and response to stdout.
-	Debug bool
-
-	// AdditionalHeaders are extra headers to add to each HTTP request sent by
-	// this Client.
-	AdditionalHeaders http.Header
-}
-
-// Generates an HTTP request, but does not perform the request.
-// The request's Accept header field will be set to:
-//
-//   Accept: application/json
-//
-// The Request-Id header will be set to a random UUID. The User-Agent header
-// will be set to the Client's UserAgent, or DefaultUserAgent if UserAgent is
-// not set.
-//
-// The type of body determines how to encode the request:
-//
-//   nil         no body
-//   io.Reader   body is sent verbatim
-//   else        body is encoded as application/json
-//
-func (c *DefaultClient) NewRequest(method, path string, body interface{}) (*http.Request, error) {
 	var ctype string
 	var rbody io.Reader
 
@@ -127,91 +45,65 @@ func (c *DefaultClient) NewRequest(method, path string, body interface{}) (*http
 
 		j, err := json.Marshal(body)
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
 		rbody = bytes.NewReader(j)
 		ctype = "application/json"
 	}
-	apiURL := strings.TrimRight(c.URL, "/")
-	if apiURL == "" {
-		apiURL = DefaultAPIURL
-	}
-	req, err := http.NewRequest(method, apiURL+path, rbody)
+	req, err := http.NewRequest(method, DefaultAPIURL+path, rbody)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Request-Id", uuid.New())
-	useragent := c.UserAgent
-	if useragent == "" {
-		useragent = DefaultUserAgent
-	}
-	req.Header.Set("User-Agent", useragent)
+	req.Header.Set("User-Agent", DefaultUserAgent)
 	if ctype != "" {
 		req.Header.Set("Content-Type", ctype)
-	}
-	req.SetBasicAuth(c.Username, c.Password)
-	for k, v := range c.AdditionalHeaders {
-		req.Header[k] = v
 	}
 	return req, nil
 }
 
-// Submits an HTTP request, checks its response, and deserializes
-// the response into v. The type of v determines how to handle
-// the response body:
-//
-//   nil        body is discarded
-//   io.Writer  body is copied directly into v
-//   else       body is decoded into v as json
-//
-func (c *DefaultClient) Do(req *http.Request, v interface{}) error {
-	if c.Debug {
-		dump, err := httputil.DumpRequestOut(req, true)
-		if err != nil {
-			log.Println(err)
-		} else {
-			log.Println(string(dump))
-		}
-	}
-
-	httpClient := c.HTTP
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	res, err := httpClient.Do(req)
+// Sends a request and decodes the response into v.
+func (s *Service) Do(v interface{}, method, path string, body interface{}, lr *ListRange) error {
+	req, err := s.NewRequest(method, path, body)
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
-	if c.Debug {
-		dump, err := httputil.DumpResponse(res, true)
-		if err != nil {
-			log.Println(err)
-		} else {
-			log.Println(string(dump))
-		}
+	if lr != nil {
+		lr.SetHeader(req)
 	}
-	if err = checkResponse(res); err != nil {
+	resp, err := s.client.Do(req)
+	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	switch t := v.(type) {
 	case nil:
 	case io.Writer:
-		_, err = io.Copy(t, res.Body)
+		_, err = io.Copy(t, resp.Body)
 	default:
-		err = json.NewDecoder(res.Body).Decode(v)
+		err = json.NewDecoder(resp.Body).Decode(v)
 	}
 	return err
 }
 
-func checkResponse(res *http.Response) error {
-	if res.StatusCode/100 != 2 { // 200, 201, 202, etc
-		// FIXME: Try to handle error json in a generic way.
-		return fmt.Errorf("Encountered an error : %s", res.Status)
-	}
-	return nil
+func (s *Service) Get(v interface{}, path string, lr *ListRange) error {
+	return s.Do(v, "GET", path, nil, lr)
+}
+
+func (s *Service) Patch(v interface{}, path string, body interface{}) error {
+	return s.Do(v, "PATCH", path, body, nil)
+}
+
+func (s *Service) Post(v interface{}, path string, body interface{}) error {
+	return s.Do(v, "POST", path, body, nil)
+}
+
+func (s *Service) Put(v interface{}, path string, body interface{}) error {
+	return s.Do(v, "PUT", path, body, nil)
+}
+
+func (s *Service) Delete(path string) error {
+	return s.Do(nil, "DELETE", path, nil, nil)
 }
 
 type ListRange struct {

--- a/schema/templates/templates.go
+++ b/schema/templates/templates.go
@@ -16,19 +16,11 @@ var templates = map[string]string{"astruct.tmpl": `{{$Root := .Root}} struct {
       return s.Delete(fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}))
     {{else if eq .Rel "self"}}
       {{$Var := initialLow $Name}}var {{$Var}} {{initialCap $Name}}
-      return &{{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}))
+      return &{{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}), nil)
     {{else if eq .Rel "instances"}}
-      req, err := s.NewRequest("GET", fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}), nil)
-      if err != nil {
-        return nil, err
-      }
-
-      if lr != nil {
-        lr.SetHeader(req)
-      }
       {{$Var := printf "%s-%s" $Name "List" | initialLow}}
       var {{$Var}} []*{{initialCap $Name}}
-      return {{$Var}}, s.Client.Do(req, &{{$Var}})
+      return {{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}), lr)
     {{else if eq .Rel "empty"}}
       return s.{{methodCap .Method}}(fmt.Sprintf("{{.HRef}}", {{args $Root .HRef}}))
     {{else}}
@@ -58,106 +50,24 @@ var templates = map[string]string{"astruct.tmpl": `{{$Root := .Root}} struct {
 	DefaultUserAgent = "{{.Name}}/" + Version + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
 )
 
-// Client is the interface that wraps HTTP request creation
-// and execution.
-type Client interface {
-	Do(req *http.Request, v interface{}) error
-	NewRequest(method, path string, body interface{}) (*http.Request, error)
-}
-
 // Service represents your API.
 type Service struct {
-	Client Client
+	client *http.Client
 }
 
 // Create a Service using the given, if none is provided
-// it uses DefaultClient.
-func NewService(client Client) *Service {
-	if client == nil {
-		client = &DefaultClient{}
+// it uses http.DefaultClient.
+func NewService(c *http.Client) *Service {
+	if c == nil {
+		c = http.DefaultClient
 	}
 	return &Service{
-		Client: client,
+		client: c,
 	}
 }
 
 // Generates an HTTP request, but does not perform the request.
 func (s *Service) NewRequest(method, path string, body interface{}) (*http.Request, error) {
-	return s.Client.NewRequest(method, path, body)
-}
-
-// Sends a request and decodes the response into v.
-func (s *Service) Do(v interface{}, method, path string, body interface{}) error {
-	req, err := s.Client.NewRequest(method, path, body)
-	if err != nil {
-		return err
-	}
-	return s.Client.Do(req, v)
-}
-
-func (s *Service) Get(v interface{}, path string) error {
-	return s.Do(v, "GET", path, nil)
-}
-
-func (s *Service) Patch(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "PATCH", path, body)
-}
-
-func (s *Service) Post(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "POST", path, body)
-}
-
-func (s *Service) Put(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "PUT", path, body)
-}
-
-func (s *Service) Delete(path string) error {
-	return s.Do(nil, "DELETE", path, nil)
-}
-
-// DefaultClient implements Client interface.
-// DefaultClient has an internal HTTP client (HTTP) which defaults to http.DefaultClient.
-type DefaultClient struct {
-	// HTTP is the Client's internal http.Client, handling HTTP requests.
-	HTTP *http.Client
-
-	// The URL of the API to communicate with.
-	URL string
-
-	// Username is the HTTP basic auth username for API calls made by this Client.
-	Username string
-
-	// Password is the HTTP basic auth password for API calls made by this Client.
-	Password string
-
-	// UserAgent to be provided in API requests. Set to DefaultUserAgent if not
-	// specified.
-	UserAgent string
-
-	// Debug mode can be used to dump the full request and response to stdout.
-	Debug bool
-
-	// AdditionalHeaders are extra headers to add to each HTTP request sent by
-	// this Client.
-	AdditionalHeaders http.Header
-}
-
-// Generates an HTTP request, but does not perform the request.
-// The request's Accept header field will be set to:
-//
-//   Accept: application/json
-//
-// The Request-Id header will be set to a random UUID. The User-Agent header
-// will be set to the Client's UserAgent, or DefaultUserAgent if UserAgent is
-// not set.
-//
-// The type of body determines how to encode the request:
-//
-//   nil         no body
-//   io.Reader   body is sent verbatim
-//   else        body is encoded as application/json
-//
-func (c *DefaultClient) NewRequest(method, path string, body interface{}) (*http.Request, error) {
 	var ctype string
 	var rbody io.Reader
 
@@ -181,91 +91,65 @@ func (c *DefaultClient) NewRequest(method, path string, body interface{}) (*http
 
 		j, err := json.Marshal(body)
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
 		rbody = bytes.NewReader(j)
 		ctype = "application/json"
 	}
-	apiURL := strings.TrimRight(c.URL, "/")
-	if apiURL == "" {
-		apiURL = DefaultAPIURL
-	}
-	req, err := http.NewRequest(method, apiURL+path, rbody)
+	req, err := http.NewRequest(method, DefaultAPIURL+path, rbody)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Request-Id", uuid.New())
-	useragent := c.UserAgent
-	if useragent == "" {
-		useragent = DefaultUserAgent
-	}
-	req.Header.Set("User-Agent", useragent)
+	req.Header.Set("User-Agent", DefaultUserAgent)
 	if ctype != "" {
 		req.Header.Set("Content-Type", ctype)
-	}
-	req.SetBasicAuth(c.Username, c.Password)
-	for k, v := range c.AdditionalHeaders {
-		req.Header[k] = v
 	}
 	return req, nil
 }
 
-// Submits an HTTP request, checks its response, and deserializes
-// the response into v. The type of v determines how to handle
-// the response body:
-//
-//   nil        body is discarded
-//   io.Writer  body is copied directly into v
-//   else       body is decoded into v as json
-//
-func (c *DefaultClient) Do(req *http.Request, v interface{}) error {
-	if c.Debug {
-		dump, err := httputil.DumpRequestOut(req, true)
-		if err != nil {
-			log.Println(err)
-		} else {
-			log.Println(string(dump))
-		}
-	}
-
-	httpClient := c.HTTP
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	res, err := httpClient.Do(req)
+// Sends a request and decodes the response into v.
+func (s *Service) Do(v interface{}, method, path string, body interface{}, lr *ListRange) error {
+	req, err := s.NewRequest(method, path, body)
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
-	if c.Debug {
-		dump, err := httputil.DumpResponse(res, true)
-		if err != nil {
-			log.Println(err)
-		} else {
-			log.Println(string(dump))
-		}
+	if lr != nil {
+		lr.SetHeader(req)
 	}
-	if err = checkResponse(res); err != nil {
+	resp, err := s.client.Do(req)
+	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	switch t := v.(type) {
 	case nil:
 	case io.Writer:
-		_, err = io.Copy(t, res.Body)
+		_, err = io.Copy(t, resp.Body)
 	default:
-		err = json.NewDecoder(res.Body).Decode(v)
+		err = json.NewDecoder(resp.Body).Decode(v)
 	}
 	return err
 }
 
-func checkResponse(res *http.Response) error {
-	if res.StatusCode/100 != 2 { // 200, 201, 202, etc
-		// FIXME: Try to handle error json in a generic way.
-		return fmt.Errorf("Encountered an error : %s", res.Status)
-	}
-	return nil
+func (s *Service) Get(v interface{}, path string, lr *ListRange) error {
+	return s.Do(v, "GET", path, nil, lr)
+}
+
+func (s *Service) Patch(v interface{}, path string, body interface{}) error {
+	return s.Do(v, "PATCH", path, body, nil)
+}
+
+func (s *Service) Post(v interface{}, path string, body interface{}) error {
+	return s.Do(v, "POST", path, body, nil)
+}
+
+func (s *Service) Put(v interface{}, path string, body interface{}) error {
+	return s.Do(v, "PUT", path, body, nil)
+}
+
+func (s *Service) Delete(path string) error {
+	return s.Do(nil, "DELETE", path, nil, nil)
 }
 
 type ListRange struct {


### PR DESCRIPTION
Use `http.Client` directly rather than adding another interface.
See [cyberdelia/heroku-go](https://github.com/cyberdelia/heroku-go), for a concrete example.

/cc @mmcgrana
