### PR TITLE
Add link.targetSchema support

### DIFF
--- a/gen_test.go
+++ b/gen_test.go
@@ -287,6 +287,125 @@ var valuesTests = []struct {
 		},
 		Values: []string{"map[string]string", "error"},
 	},
+	{
+		Schema: &Schema{},
+		Name:   "Result",
+		Link: &Link{
+			Rel:   "instances",
+			Title: "List",
+			TargetSchema: &Schema{
+				Type: "object",
+				Properties: map[string]*Schema{
+					"value": {
+						Type: "integer",
+					},
+				},
+			},
+		},
+		Values: []string{"[]*ResultListResult", "error"},
+	},
+	{
+		Schema: &Schema{
+			Type: "object",
+			Properties: map[string]*Schema{
+				"value": {
+					Type: "integer",
+				},
+			},
+			Required: []string{"value"},
+		},
+		Name: "Result",
+		Link: &Link{
+			Rel:   "self",
+			Title: "Info",
+			TargetSchema: &Schema{
+				Type: "object",
+				Properties: map[string]*Schema{
+					"value": {
+						Type: "integer",
+					},
+				},
+			},
+		},
+		Values: []string{"*ResultInfoResult", "error"},
+	},
+	{
+		Schema: &Schema{
+			Type:                 "object",
+			AdditionalProperties: false,
+			PatternProperties: map[string]*Schema{
+				"^\\w+$": {
+					Type: "string",
+				},
+			},
+		},
+		Name: "ConfigVar",
+		Link: &Link{
+			Rel:   "self",
+			Title: "Info",
+			TargetSchema: &Schema{
+				Type: "object",
+				Properties: map[string]*Schema{
+					"value": {
+						Type: "integer",
+					},
+				},
+			},
+		},
+		Values: []string{"*ConfigVarInfoResult", "error"},
+	},
+	{
+		Schema: &Schema{},
+		Name:   "Result",
+		Link: &Link{
+			Rel:   "instances",
+			Title: "List",
+			TargetSchema: &Schema{
+				Type: "string",
+			},
+		},
+		Values: []string{"[]*string", "error"},
+	},
+	{
+		Schema: &Schema{
+			Type: "object",
+			Properties: map[string]*Schema{
+				"value": {
+					Type: "integer",
+				},
+			},
+			Required: []string{"value"},
+		},
+		Name: "Result",
+		Link: &Link{
+			Rel:   "self",
+			Title: "Info",
+			TargetSchema: &Schema{
+				Type: "string",
+			},
+		},
+		Values: []string{"string", "error"},
+	},
+	{
+		Schema: &Schema{
+			Type:                 "object",
+			AdditionalProperties: false,
+			PatternProperties: map[string]*Schema{
+				"^\\w+$": {
+					Type: "string",
+				},
+			},
+		},
+		Name: "ConfigVar",
+		Link: &Link{
+			Rel:   "self",
+			Title: "Info",
+			TargetSchema: &Schema{
+				Type: "string",
+			},
+		},
+		Values: []string{"string", "error"},
+	},
 }
 
 func TestValues(t *testing.T) {

--- a/helpers.go
+++ b/helpers.go
@@ -12,15 +12,18 @@ import (
 )
 
 var helpers = template.FuncMap{
-	"initialCap": initialCap,
-	"initialLow": initialLow,
-	"methodCap":  methodCap,
-	"asComment":  asComment,
-	"jsonTag":    jsonTag,
-	"params":     params,
-	"args":       args,
-	"values":     values,
-	"goType":     goType,
+	"initialCap":       initialCap,
+	"initialLow":       initialLow,
+	"methodCap":        methodCap,
+	"asComment":        asComment,
+	"jsonTag":          jsonTag,
+	"params":           params,
+	"requestParams":    requestParams,
+	"args":             args,
+	"values":           values,
+	"goType":           goType,
+	"returnType":       returnType,
+	"defineCustomType": defineCustomType,
 }
 
 var (
@@ -133,6 +136,14 @@ func params(l *Link) string {
 	return strings.Join(p, ", ")
 }
 
+func requestParams(l *Link) string {
+	_, params := l.Parameters()
+	if _, ok := params["o"]; ok {
+		return "o"
+	}
+	return "nil"
+}
+
 func args(h *HRef) string {
 	return strings.Join(h.Order, ", ")
 }
@@ -143,4 +154,15 @@ func sortedKeys(m map[string]*Schema) (keys []string) {
 	}
 	sort.Strings(keys)
 	return
+}
+
+func returnType(name string, s *Schema, l *Link) string {
+	if defineCustomType(s, l) {
+		return initialCap(fmt.Sprintf("%s-%s-Result", name, l.Title))
+	}
+	return initialCap(name)
+}
+
+func defineCustomType(s *Schema, l *Link) bool {
+	return l.TargetSchema != nil && s.ReturnsCustomType(l)
 }

--- a/schema.go
+++ b/schema.go
@@ -62,10 +62,11 @@ type Schema struct {
 
 // Link represents a Link description.
 type Link struct {
-	Title       string  `json:"title,omitempty"`
-	Description string  `json:"description,omitempty"`
-	HRef        *HRef   `json:"href,omitempty"`
-	Rel         string  `json:"rel,omitempty"`
-	Method      string  `json:"method,omitempty"`
-	Schema      *Schema `json:"schema,omitempty"`
+	Title        string  `json:"title,omitempty"`
+	Description  string  `json:"description,omitempty"`
+	HRef         *HRef   `json:"href,omitempty"`
+	Rel          string  `json:"rel,omitempty"`
+	Method       string  `json:"method,omitempty"`
+	Schema       *Schema `json:"schema,omitempty"`
+	TargetSchema *Schema `json:"targetSchema,omitempty"`
 }

--- a/templates/funcs.tmpl
+++ b/templates/funcs.tmpl
@@ -4,23 +4,26 @@
   {{if eq .Rel "update" "create" }}
    type {{printf "%s-%s-Opts" $Name .Title | initialCap}} {{.GoType}}
   {{end}}
+  {{if (defineCustomType $Def .)}}
+   type {{returnType $Name $Def .}} {{$Def.ReturnedGoType .}}
+  {{end}}
 
   {{asComment .Description}}
   func (s *Service) {{printf "%s-%s" $Name .Title | initialCap}}({{params .}}) ({{values $Name $Def .}}) {
     {{if eq .Rel "destroy"}}
       return s.Delete(fmt.Sprintf("{{.HRef}}", {{args .HRef}}))
     {{else if eq .Rel "self"}}
-      {{$Var := initialLow $Name}}var {{$Var}} {{initialCap $Name}}
-      return {{if $Def.IsCustomType}}&{{end}}{{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}), nil)
+      {{$Var := initialLow $Name}}var {{$Var}} {{returnType $Name $Def .}}
+      return {{if ($Def.ReturnsCustomType .)}}&{{end}}{{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}), nil)
     {{else if eq .Rel "instances"}}
       {{$Var := printf "%s-%s" $Name "List" | initialLow}}
-      var {{$Var}} []*{{initialCap $Name}}
+      var {{$Var}} []*{{returnType $Name $Def .}}
       return {{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}), lr)
     {{else if eq .Rel "empty"}}
       return s.{{methodCap .Method}}(fmt.Sprintf("{{.HRef}}", {{args .HRef}}))
     {{else}}
-      {{$Var := initialLow $Name}}var {{$Var}} {{initialCap $Name}}
-      return {{if $Def.IsCustomType}}&{{end}}{{$Var}}, s.{{methodCap .Method}}(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}), o)
+      {{$Var := initialLow $Name}}var {{$Var}} {{returnType $Name $Def .}}
+      return {{if ($Def.ReturnsCustomType .)}}&{{end}}{{$Var}}, s.{{methodCap .Method}}(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}), {{requestParams .}})
     {{end}}
   }
 {{end}}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -10,23 +10,26 @@ var templates = map[string]string{"field.tmpl": `{{initialCap .Name}} {{.Type}} 
   {{if eq .Rel "update" "create" }}
    type {{printf "%s-%s-Opts" $Name .Title | initialCap}} {{.GoType}}
   {{end}}
+  {{if (defineCustomType $Def .)}}
+   type {{returnType $Name $Def .}} {{$Def.ReturnedGoType .}}
+  {{end}}
 
   {{asComment .Description}}
   func (s *Service) {{printf "%s-%s" $Name .Title | initialCap}}({{params .}}) ({{values $Name $Def .}}) {
     {{if eq .Rel "destroy"}}
       return s.Delete(fmt.Sprintf("{{.HRef}}", {{args .HRef}}))
     {{else if eq .Rel "self"}}
-      {{$Var := initialLow $Name}}var {{$Var}} {{initialCap $Name}}
-      return {{if $Def.IsCustomType}}&{{end}}{{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}), nil)
+      {{$Var := initialLow $Name}}var {{$Var}} {{returnType $Name $Def .}}
+      return {{if ($Def.ReturnsCustomType .)}}&{{end}}{{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}), nil)
     {{else if eq .Rel "instances"}}
       {{$Var := printf "%s-%s" $Name "List" | initialLow}}
-      var {{$Var}} []*{{initialCap $Name}}
+      var {{$Var}} []*{{returnType $Name $Def .}}
       return {{$Var}}, s.Get(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}), lr)
     {{else if eq .Rel "empty"}}
       return s.{{methodCap .Method}}(fmt.Sprintf("{{.HRef}}", {{args .HRef}}))
     {{else}}
-      {{$Var := initialLow $Name}}var {{$Var}} {{initialCap $Name}}
-      return {{if $Def.IsCustomType}}&{{end}}{{$Var}}, s.{{methodCap .Method}}(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}), o)
+      {{$Var := initialLow $Name}}var {{$Var}} {{returnType $Name $Def .}}
+      return {{if ($Def.ReturnsCustomType .)}}&{{end}}{{$Var}}, s.{{methodCap .Method}}(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}), {{requestParams .}})
     {{end}}
   }
 {{end}}
@@ -232,7 +235,6 @@ type {{initialCap .Name}} {{goType .Definition}}
 `,
 }
 
-// Parse parses declared templates.
 func Parse(t *template.Template) (*template.Template, error) {
 	for name, s := range templates {
 		var tmpl *template.Template


### PR DESCRIPTION
Hi @cyberdelia,

Here's my first take on support for targetSchema (issue #24)

I've used it with my API and it seems to be working nicely.

One big question: what should be returned for `rel: instances`?

According to JSON Hyper-Schema:

> instances: This indicates the target resource that represents a collection of instances of a schema.

So I've set rel instances to return an array of targetSchema resources rather than returning targetSchema itself.

Let me know what you think.
