### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Generate Go client code for HTTP APIs described by [JSON Hyper-Schemas](http://j
 Download and install:
 
 ```console
-$ go get -u github.com/interagent/schematic
+$ go get -u github.com/interagent/schematic/cmd/schematic
 ```
 
 **Warning**: schematic requires Go >= 1.2.


### PR DESCRIPTION
`go get -u github.com/interagent/schematic` wont install `cmd/schematic`
