### PR TITLE
Fixing support for Array schemas and targetSchemas

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -213,6 +213,8 @@ func (s *Schema) Values(name string, l *Link) []string {
 		values = append(values, "error")
 	} else if s.ReturnsCustomType(l) {
 		values = append(values, fmt.Sprintf("*%s", name), "error")
+	} else if s.ReturnsArray(l) {
+		values = append(values, fmt.Sprintf("[]%s", name), "error")
 	} else {
 		values = append(values, s.ReturnedGoType(l), "error")
 	}
@@ -235,6 +237,14 @@ func (s *Schema) ReturnsCustomType(l *Link) bool {
 		return len(l.TargetSchema.Properties) > 0
 	}
 	return len(s.Properties) > 0
+}
+
+// ReturnsArray returns true if the link returns an array.
+func (s *Schema) ReturnsArray(l *Link) bool {
+	if l.TargetSchema != nil {
+		return l.TargetSchema.Items != nil
+	}
+	return s.Items != nil
 }
 
 // ReturnedGoType returns Go type returned by the given link as a string.

--- a/gen_test.go
+++ b/gen_test.go
@@ -508,6 +508,45 @@ var valuesTests = []struct {
 		},
 		Values: []string{"string", "error"},
 	},
+	{
+		Schema: &Schema{},
+		Name:   "Result",
+		Link: &Link{
+			Rel:   "result",
+			Title: "List",
+			TargetSchema: &Schema{
+				Type: "array",
+				Items: &Schema{
+					Properties: map[string]*Schema{
+						"value": {
+							Type: "integer",
+						},
+					},
+					Type: "object",
+				},
+			},
+		},
+		Values: []string{"[]ResultListResult", "error"},
+	},
+	{
+		Schema: &Schema{
+			Type: "array",
+			Items: &Schema{
+				Properties: map[string]*Schema{
+					"value": {
+						Type: "integer",
+					},
+				},
+				Type: "object",
+			},
+		},
+		Name: "Result",
+		Link: &Link{
+			Rel:   "result",
+			Title: "List",
+		},
+		Values: []string{"[]Result", "error"},
+	},
 }
 
 func TestValues(t *testing.T) {

--- a/helpers.go
+++ b/helpers.go
@@ -12,20 +12,21 @@ import (
 )
 
 var helpers = template.FuncMap{
-	"initialCap":       initialCap,
-	"initialLow":       initialLow,
-	"methodCap":        methodCap,
-	"asComment":        asComment,
-	"fieldTag":         fieldTag,
-	"params":           params,
-	"requestParams":    requestParams,
-	"args":             args,
-	"values":           values,
-	"goType":           goType,
-	"linkGoType":       linkGoType,
-	"returnType":       returnType,
-	"defineCustomType": defineCustomType,
-	"paramType":        paramType,
+	"initialCap":        initialCap,
+	"initialLow":        initialLow,
+	"methodCap":         methodCap,
+	"asComment":         asComment,
+	"fieldTag":          fieldTag,
+	"params":            params,
+	"requestParams":     requestParams,
+	"args":              args,
+	"values":            values,
+	"goType":            goType,
+	"linkGoType":        linkGoType,
+	"returnType":        returnType,
+	"defineCustomType":  defineCustomType,
+	"defineCustomArray": defineCustomArray,
+	"paramType":         paramType,
 }
 
 var (
@@ -190,6 +191,8 @@ func sortedKeys(m map[string]*Schema) (keys []string) {
 func returnType(name string, s *Schema, l *Link) string {
 	if defineCustomType(s, l) {
 		return initialCap(fmt.Sprintf("%s-%s-Result", name, l.Title))
+	} else if defineCustomArray(s, l) {
+		return initialCap(fmt.Sprintf("%s-%s-Result", name, l.Title))
 	}
 	return initialCap(name)
 }
@@ -203,4 +206,8 @@ func paramType(name string, l *Link) string {
 
 func defineCustomType(s *Schema, l *Link) bool {
 	return l.TargetSchema != nil && s.ReturnsCustomType(l)
+}
+
+func defineCustomArray(s *Schema, l *Link) bool {
+	return l.TargetSchema != nil && s.ReturnsArray(l)
 }

--- a/templates/funcs.tmpl
+++ b/templates/funcs.tmpl
@@ -7,6 +7,8 @@
 
   {{if (defineCustomType $Def .)}}
    type {{returnType $Name $Def .}} {{$Def.ReturnedGoType .}}
+  {{else if (defineCustomArray $Def .)}}
+   type {{returnType $Name $Def .}} {{.TargetSchema.Items.GoType}}
   {{end}}
 
   {{asComment .Description}}
@@ -14,7 +16,7 @@
     {{if ($Def.EmptyResult .)}}
       return s.{{methodCap .Method}}(nil, fmt.Sprintf("{{.HRef}}", {{args .HRef}}){{requestParams .}})
     {{else}}
-      {{$Var := initialLow $Name}}var {{$Var}} {{returnType $Name $Def .}}
+      {{$Var := initialLow $Name}}var {{$Var}} {{if ($Def.ReturnsArray .)}}[]{{end}}{{returnType $Name $Def .}}
       return {{if ($Def.ReturnsCustomType .)}}&{{end}}{{$Var}}, s.{{methodCap .Method}}(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}){{requestParams .}})
     {{end}}
   }

--- a/templates/struct.tmpl
+++ b/templates/struct.tmpl
@@ -1,2 +1,6 @@
 {{asComment .Definition.Description}}
+{{if (.Definition.Items)}}
+type {{initialCap .Name}} {{goType .Definition.Items}}
+{{else}}
 type {{initialCap .Name}} {{goType .Definition}}
+{{end}}


### PR DESCRIPTION
This is a first take on supporting arrays in Schema or TargetSchema
rather than objects.

Pending:
- Support for optional arrays
