### PR TITLE
added EncType and MediaType to Link

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -69,4 +69,6 @@ type Link struct {
 	Method       string  `json:"method,omitempty"`
 	Schema       *Schema `json:"schema,omitempty"`
 	TargetSchema *Schema `json:"targetSchema,omitempty"`
+	MediaType    string  `json:"mediaType,omitempty"`
+	EncType      string  `json:"encType,omitempty"`
 }


### PR DESCRIPTION
These are defined in JSON Hyper-Schema draft v4.
- `mediaType`
  - http://json-schema.org/latest/json-schema-hypermedia.html#anchor33
- `encType`
  - http://json-schema.org/latest/json-schema-hypermedia.html#anchor37
