### PR TITLE
Fixing asComment method cannot handle multibyte characters

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -122,21 +122,31 @@ func asComment(c string) string {
 	removeNewlines := func(s string) string {
 		return strings.Replace(s, "\n", "\n// ", -1)
 	}
-	for len(c) > 0 {
-		line := c
+	findLastIndex := func(rs []rune, r rune) int {
+		l := -1
+		for i, v := range rs {
+			if v == r {
+				l = i
+			}
+		}
+		return l
+	}
+	r := []rune(c)
+	for len(r) > 0 {
+		line := r
 		if len(line) < maxLen {
-			fmt.Fprintf(&buf, "// %s\n", removeNewlines(line))
+			fmt.Fprintf(&buf, "// %s\n", removeNewlines(string(line)))
 			break
 		}
 		line = line[:maxLen]
-		si := strings.LastIndex(line, " ")
+		si := findLastIndex(line, []rune(" ")[0])
 		if si != -1 {
 			line = line[:si]
 		}
-		fmt.Fprintf(&buf, "// %s\n", removeNewlines(line))
-		c = c[len(line):]
+		fmt.Fprintf(&buf, "// %s\n", removeNewlines(string(line)))
+		r = r[len(line):]
 		if si != -1 {
-			c = c[1:]
+			r = r[1:]
 		}
 	}
 	return buf.String()


### PR DESCRIPTION
Original asComment method breaks character because of its way to separate sentence.

For exmaple "あいうえお" has 5 characters but it contains 15 bytes (3 bytes per 1 character) in UTF-8.
If we separate it by 5 bytes it will be broken.

As a result of the broken text, `format.Source` in Generate method in gen.go reports error something like `illegal UTF-8 encoding`.

This PR changes asComment method that it able to handle maxLen as a number of character count not byte count. So most case in single byte characters such as English would not be affected by this changes.
