### PR TITLE
Allows references that point to parent definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: go
 go:
   - 1.7
   - 1.8
-install: go get golang.org/x/tools/cmd/cover
 script: go test -race -cover ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.2
-  - 1.3
-install: go get code.google.com/p/go.tools/cmd/cover
+  - 1.7
+  - 1.8
+install: go get golang.org/x/tools/cmd/cover
 script: go test -race -cover ./...

--- a/gen.go
+++ b/gen.go
@@ -18,15 +18,15 @@ func init() {
 	templates = template.Must(bundle.Parse(templates))
 }
 
-// resolvedSet stores a set of pointers to objects that have already been
+// ResolvedSet stores a set of pointers to objects that have already been
 // resolved to prevent infinite loops.
-type resolvedSet map[interface{}]bool
+type ResolvedSet map[interface{}]bool
 
-func (rs resolvedSet) Insert(o interface{}) {
+func (rs ResolvedSet) Insert(o interface{}) {
 	rs[o] = true
 }
 
-func (rs resolvedSet) Has(o interface{}) bool {
+func (rs ResolvedSet) Has(o interface{}) bool {
 	return rs[o]
 }
 
@@ -34,7 +34,7 @@ func (rs resolvedSet) Has(o interface{}) bool {
 func (s *Schema) Generate() ([]byte, error) {
 	var buf bytes.Buffer
 
-	s = s.Resolve(nil, resolvedSet{})
+	s = s.Resolve(nil, ResolvedSet{})
 
 	name := strings.ToLower(strings.Split(s.Title, " ")[0])
 	templates.ExecuteTemplate(&buf, "package.tmpl", name)
@@ -88,7 +88,7 @@ func (s *Schema) Generate() ([]byte, error) {
 }
 
 // Resolve resolves reference inside the schema.
-func (s *Schema) Resolve(r *Schema, rs resolvedSet) *Schema {
+func (s *Schema) Resolve(r *Schema, rs ResolvedSet) *Schema {
 	if r == nil {
 		r = s
 	}
@@ -323,7 +323,7 @@ func (l *Link) AcceptsCustomType() bool {
 }
 
 // Resolve resolve link schema and href.
-func (l *Link) Resolve(r *Schema, rs resolvedSet) {
+func (l *Link) Resolve(r *Schema, rs ResolvedSet) {
 	if l.Schema != nil {
 		l.Schema = l.Schema.Resolve(r, rs)
 	}

--- a/gen.go
+++ b/gen.go
@@ -18,13 +18,23 @@ func init() {
 	templates = template.Must(bundle.Parse(templates))
 }
 
+// resolvedSet stores a set of pointers to objects that have already been
+// resolved to prevent infinite loops.
+type resolvedSet map[interface{}]bool
+
+func (rs resolvedSet) Insert(o interface{}) {
+	rs[o] = true
+}
+
+func (rs resolvedSet) Has(o interface{}) bool {
+	return rs[o]
+}
+
 // Generate generates code according to the schema.
 func (s *Schema) Generate() ([]byte, error) {
 	var buf bytes.Buffer
 
-	for i := 0; i < 2; i++ {
-		s.Resolve(nil)
-	}
+	s = s.Resolve(nil, resolvedSet{})
 
 	name := strings.ToLower(strings.Split(s.Title, " ")[0])
 	templates.ExecuteTemplate(&buf, "package.tmpl", name)
@@ -78,33 +88,43 @@ func (s *Schema) Generate() ([]byte, error) {
 }
 
 // Resolve resolves reference inside the schema.
-func (s *Schema) Resolve(r *Schema) *Schema {
+func (s *Schema) Resolve(r *Schema, rs resolvedSet) *Schema {
 	if r == nil {
 		r = s
 	}
+
+	for {
+		if s.Ref != nil {
+			s = s.Ref.Resolve(r)
+		} else if len(s.OneOf) > 0 {
+			s = s.OneOf[0].Ref.Resolve(r)
+		} else if len(s.AnyOf) > 0 {
+			s = s.AnyOf[0].Ref.Resolve(r)
+		} else {
+			break
+		}
+	}
+
+	if rs.Has(s) {
+		// Already resolved
+		return s
+	}
+	rs.Insert(s)
+
 	for n, d := range s.Definitions {
-		s.Definitions[n] = d.Resolve(r)
+		s.Definitions[n] = d.Resolve(r, rs)
 	}
 	for n, p := range s.Properties {
-		s.Properties[n] = p.Resolve(r)
+		s.Properties[n] = p.Resolve(r, rs)
 	}
 	for n, p := range s.PatternProperties {
-		s.PatternProperties[n] = p.Resolve(r)
+		s.PatternProperties[n] = p.Resolve(r, rs)
 	}
 	if s.Items != nil {
-		s.Items = s.Items.Resolve(r)
-	}
-	if s.Ref != nil {
-		s = s.Ref.Resolve(r)
-	}
-	if len(s.OneOf) > 0 {
-		s = s.OneOf[0].Ref.Resolve(r)
-	}
-	if len(s.AnyOf) > 0 {
-		s = s.AnyOf[0].Ref.Resolve(r)
+		s.Items = s.Items.Resolve(r, rs)
 	}
 	for _, l := range s.Links {
-		l.Resolve(r)
+		l.Resolve(r, rs)
 	}
 	return s
 }
@@ -303,14 +323,14 @@ func (l *Link) AcceptsCustomType() bool {
 }
 
 // Resolve resolve link schema and href.
-func (l *Link) Resolve(r *Schema) {
+func (l *Link) Resolve(r *Schema, rs resolvedSet) {
 	if l.Schema != nil {
-		l.Schema = l.Schema.Resolve(r)
+		l.Schema = l.Schema.Resolve(r, rs)
 	}
 	if l.TargetSchema != nil {
-		l.TargetSchema = l.TargetSchema.Resolve(r)
+		l.TargetSchema = l.TargetSchema.Resolve(r, rs)
 	}
-	l.HRef.Resolve(r)
+	l.HRef.Resolve(r, rs)
 }
 
 // GoType returns Go type for the given schema as string and a bool specifying whether it is required

--- a/gen_test.go
+++ b/gen_test.go
@@ -82,7 +82,7 @@ func TestResolve(t *testing.T) {
 				}
 			}()
 
-			rt.Schema.Resolve(nil, resolvedSet{})
+			rt.Schema.Resolve(nil, ResolvedSet{})
 		})
 	}
 }
@@ -385,7 +385,7 @@ var paramsTests = []struct {
 
 func TestParameters(t *testing.T) {
 	for i, pt := range paramsTests {
-		pt.Link.Resolve(pt.Schema, resolvedSet{})
+		pt.Link.Resolve(pt.Schema, ResolvedSet{})
 		order, params := pt.Link.Parameters("link")
 		if !reflect.DeepEqual(order, pt.Order) {
 			t.Errorf("%d: wants %v, got %v", i, pt.Order, order)

--- a/helpers.go
+++ b/helpers.go
@@ -31,7 +31,7 @@ var helpers = template.FuncMap{
 var (
 	newlines  = regexp.MustCompile(`(?m:\s*$)`)
 	acronyms  = regexp.MustCompile(`(Url|Http|Id|Io|Uuid|Api|Uri|Ssl|Cname|Oauth|Otp)$`)
-	camelcase = regexp.MustCompile(`(?m)[-.$/:_{}\s]`)
+	camelcase = regexp.MustCompile(`(?m)[-.$/:_{}\s]+`)
 )
 
 func goType(p *Schema) string {

--- a/reference.go
+++ b/reference.go
@@ -18,6 +18,13 @@ var href = regexp.MustCompile(`({\([^\)]+)\)}`)
 // Reference represents a JSON Reference.
 type Reference string
 
+// NewReference creates a new Reference based on a reference value.
+func NewReference(ref string) *Reference {
+	r := new(Reference)
+	*r = Reference(ref)
+	return r
+}
+
 // Resolve resolves reference inside a Schema.
 func (rf Reference) Resolve(r *Schema) *Schema {
 	if !strings.HasPrefix(string(rf), fragment) {
@@ -95,7 +102,7 @@ func NewHRef(href string) *HRef {
 }
 
 // Resolve resolves a href inside a Schema.
-func (h *HRef) Resolve(r *Schema) {
+func (h *HRef) Resolve(r *Schema, rs resolvedSet) {
 	h.Order = make([]string, 0)
 	h.Schemas = make(map[string]*Schema)
 	for _, v := range href.FindAllString(string(h.href), -1) {
@@ -106,7 +113,7 @@ func (h *HRef) Resolve(r *Schema) {
 		parts := strings.Split(u, "/")
 		name := initialLow(fmt.Sprintf("%s-%s", parts[len(parts)-3], parts[len(parts)-1]))
 		h.Order = append(h.Order, name)
-		h.Schemas[name] = Reference(u).Resolve(r)
+		h.Schemas[name] = Reference(u).Resolve(r).Resolve(r, rs)
 	}
 }
 

--- a/reference.go
+++ b/reference.go
@@ -102,7 +102,7 @@ func NewHRef(href string) *HRef {
 }
 
 // Resolve resolves a href inside a Schema.
-func (h *HRef) Resolve(r *Schema, rs resolvedSet) {
+func (h *HRef) Resolve(r *Schema, rs ResolvedSet) {
 	h.Order = make([]string, 0)
 	h.Schemas = make(map[string]*Schema)
 	for _, v := range href.FindAllString(string(h.href), -1) {

--- a/reference_test.go
+++ b/reference_test.go
@@ -113,7 +113,7 @@ var hrefTests = []struct {
 func TestHREfResolve(t *testing.T) {
 	for i, ht := range hrefTests {
 		href := NewHRef(ht.HRef)
-		href.Resolve(ht.Schema, resolvedSet{})
+		href.Resolve(ht.Schema, ResolvedSet{})
 		if !reflect.DeepEqual(href.Order, ht.Order) {
 			t.Errorf("%d: resolved order don't match, got %v, wants %v", i, href.Order, ht.Order)
 		}

--- a/reference_test.go
+++ b/reference_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var resolveTests = []struct {
+var refResolveTests = []struct {
 	Ref      string
 	Schema   *Schema
 	Resolved *Schema
@@ -43,7 +43,7 @@ var resolveTests = []struct {
 }
 
 func TestReferenceResolve(t *testing.T) {
-	for i, rt := range resolveTests {
+	for i, rt := range refResolveTests {
 		ref := Reference(rt.Ref)
 		rsl := ref.Resolve(rt.Schema)
 		if !reflect.DeepEqual(rsl, rt.Resolved) {
@@ -113,7 +113,7 @@ var hrefTests = []struct {
 func TestHREfResolve(t *testing.T) {
 	for i, ht := range hrefTests {
 		href := NewHRef(ht.HRef)
-		href.Resolve(ht.Schema)
+		href.Resolve(ht.Schema, resolvedSet{})
 		if !reflect.DeepEqual(href.Order, ht.Order) {
 			t.Errorf("%d: resolved order don't match, got %v, wants %v", i, href.Order, ht.Order)
 		}

--- a/schema.go
+++ b/schema.go
@@ -57,7 +57,7 @@ type Schema struct {
 	Not   *Schema  `json:"not,omitempty"`
 
 	// Links
-	Links []Link `json:"links,omitempty"`
+	Links []*Link `json:"links,omitempty"`
 }
 
 // Link represents a Link description.


### PR DESCRIPTION
Fixes #29 

## Highlights
* Introduces a `ResolvedSet` structure to mark references that have been (or are currently being) resolved, to avoid infinite loops.
* Resolves references eagerly before child elements are resolved. This is more in line with [the spec], which states that elements with `$ref` should be replaced entirely with the representation that they point to.

Note that this still doesn't quite correctly generate the Heroku Platform API schema due to bugs in the schema itself (missing `type` information on some schemas). I've submitted a PR against the API to get that issue addressed, but until it's merged I've created [a gist of the schema.json from my PR branch](https://gist.githubusercontent.com/alindeman/5fc3d864461da931f2e53139e16be7ad/raw/21de672686ff522b6f299755e232204a75728d89/schema.json) to test against.

[the spec]: https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.28