### PR TITLE
Additional fixes for Heroku schema generation

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -234,7 +234,7 @@ func (s *Schema) Values(name string, l *Link) []string {
 	} else if s.ReturnsCustomType(l) {
 		values = append(values, fmt.Sprintf("*%s", name), "error")
 	} else {
-		values = append(values, s.ReturnedGoType(l), "error")
+		values = append(values, name, "error")
 	}
 	return values
 }

--- a/gen.go
+++ b/gen.go
@@ -278,9 +278,9 @@ func (s *Schema) ReturnsCustomType(l *Link) bool {
 // ReturnedGoType returns Go type returned by the given link as a string.
 func (s *Schema) ReturnedGoType(l *Link) string {
 	if l.TargetSchema != nil {
-		return l.TargetSchema.goType(true, false)
+		return l.TargetSchema.goType(true, true)
 	}
-	return s.goType(true, false)
+	return s.goType(true, true)
 }
 
 // EmptyResult retursn true if the link result should be empty.

--- a/gen.go
+++ b/gen.go
@@ -239,6 +239,24 @@ func (s *Schema) Values(name string, l *Link) []string {
 	return values
 }
 
+// UniqueLinks returns a list of links, unique by title.
+//
+// If more than one link in a given schema has the same title, only the one
+// appearing last will appear in this list. This matches the behavior of the
+// heroics Ruby gem and avoids generating structs and funcs with duplicate
+// names.
+func (s *Schema) UniqueLinks() []*Link {
+	titles := map[string]bool{}
+	var uniqueLinks []*Link
+	for _, link := range s.Links {
+		if _, ok := titles[link.Title]; !ok {
+			uniqueLinks = append(uniqueLinks, link)
+		}
+		titles[link.Title] = true
+	}
+	return uniqueLinks
+}
+
 // URL returns schema base URL.
 func (s *Schema) URL() string {
 	for _, l := range s.Links {

--- a/gen_test.go
+++ b/gen_test.go
@@ -456,7 +456,7 @@ var valuesTests = []struct {
 		Link: &Link{
 			Rel: "self",
 		},
-		Values: []string{"map[string]string", "error"},
+		Values: []string{"ConfigVar", "error"},
 	},
 	{
 		Schema: &Schema{},
@@ -501,6 +501,23 @@ var valuesTests = []struct {
 		Values: []string{"*ResultInfoResult", "error"},
 	},
 	{
+		Schema: &Schema{},
+		Name:   "ConfigVar",
+		Link: &Link{
+			Rel:   "self",
+			Title: "Info",
+			TargetSchema: &Schema{
+				Type: "object",
+				Properties: map[string]*Schema{
+					"value": {
+						Type: "integer",
+					},
+				},
+			},
+		},
+		Values: []string{"*ConfigVarInfoResult", "error"},
+	},
+	{
 		Schema: &Schema{
 			Type:                 "object",
 			AdditionalProperties: false,
@@ -535,7 +552,7 @@ var valuesTests = []struct {
 				Type: "string",
 			},
 		},
-		Values: []string{"string", "error"},
+		Values: []string{"ResultListResult", "error"},
 	},
 	{
 		Schema: &Schema{},
@@ -547,7 +564,7 @@ var valuesTests = []struct {
 				Type: []interface{}{"string", "null"},
 			},
 		},
-		Values: []string{"*string", "error"},
+		Values: []string{"ResultListResult", "error"},
 	},
 	{
 		Schema: &Schema{
@@ -567,7 +584,7 @@ var valuesTests = []struct {
 				Type: "string",
 			},
 		},
-		Values: []string{"string", "error"},
+		Values: []string{"ResultInfoResult", "error"},
 	},
 	{
 		Schema: &Schema{
@@ -587,7 +604,7 @@ var valuesTests = []struct {
 				Type: "string",
 			},
 		},
-		Values: []string{"string", "error"},
+		Values: []string{"ConfigVarInfoResult", "error"},
 	},
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -202,5 +202,5 @@ func paramType(name string, l *Link) string {
 }
 
 func defineCustomType(s *Schema, l *Link) bool {
-	return l.TargetSchema != nil && s.ReturnsCustomType(l)
+	return l.TargetSchema != nil
 }

--- a/templates/funcs.tmpl
+++ b/templates/funcs.tmpl
@@ -1,6 +1,6 @@
 {{$Name := .Name}}
 {{$Def := .Definition}}
-{{range .Definition.Links}}
+{{range .Definition.UniqueLinks}}
   {{if .AcceptsCustomType}}
    type {{paramType $Name .}} {{linkGoType .}}
   {{end}}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -6,7 +6,7 @@ var templates = map[string]string{"field.tmpl": `{{initialCap .Name}} {{.Type}} 
 `,
 	"funcs.tmpl": `{{$Name := .Name}}
 {{$Def := .Definition}}
-{{range .Definition.Links}}
+{{range .Definition.UniqueLinks}}
   {{if .AcceptsCustomType}}
    type {{paramType $Name .}} {{linkGoType .}}
   {{end}}


### PR DESCRIPTION
In this branch, I make two additional changes that I ended up figuring out were needed to correctly generate the Heroku Platform API from **schematic**:

* If two or more `links` within the same (sub-)schema have the same `title`, only the last one is generated. There are a few cases in the Heroku Platform API schema where this happens, and while it has the result of not generating certain routes, it matches [the current behavior of the `heroics` gem](https://github.com/interagent/heroics/blob/44c31a7988d0e4203a9687c68c18370bab39b54c/lib/heroics/schema.rb#L63-L66) and therefore I think it's a reasonable step to take here too, at least until we have some time to propose updating the `title` attributes in the Heroku schema to be unique. That is: we're not doing anything worse than what `heroics` does, even though it's not ideal.
* Always generates a custom type definition, even if it ends up typedef'ed to `string` or `*string` or `map[...]`.

More on that last point! Previously code was being generated like this:

```go
// Restart dyno.
func (s *Service) DynoRestart(appIdentity string, dynoIdentity string) (struct{}, error) {
        var dyno Dyno
        return dyno, s.Delete(&dyno, fmt.Sprintf("/apps/%v/dynos/%v", appIdentity, dynoIdentity))
}
```

This is a compilation error because `struct{}` is not compatible with `Dyno`. The _correct_ return type is `struct{}`, because this route has a documented empty reply, but because of some inconsistencies in the way return types were generated for the method signature versus the method body, we came up with incompatible types. I determined that one of the better ways to work around this issue is to _always_ generate a custom type, so we end up with methods looking like this:

```go
type DynoRestartResult struct{}

// Restart dyno.
func (s *Service) DynoRestart(appIdentity string, dynoIdentity string) (DynoRestartResult, error) {
        var dyno DynoRestartResult
        return dyno, s.Delete(&dyno, fmt.Sprintf("/apps/%v/dynos/%v", appIdentity, dynoIdentity))
}
```

This is correct and compiles correctly.

Note that instead of bare `maps` or slices now, we also get methods generated like this:

```go
type ConfigVarInfoForAppResult map[string]*string

// Get config-vars for app.
func (s *Service) ConfigVarInfoForApp(appIdentity string) (ConfigVarInfoForAppResult, error) {
        var configVar ConfigVarInfoForAppResult
        return configVar, s.Get(&configVar, fmt.Sprintf("/apps/%v/config-vars", appIdentity), nil, nil)
}
```

and

```go
type AccountFeatureListResult []struct {
        CreatedAt   *time.Time `json:"created_at,omitempty" url:"created_at,omitempty,key"`   // when account feature was created
        Description *string    `json:"description,omitempty" url:"description,omitempty,key"` // description of account feature
        DocURL      *string    `json:"doc_url,omitempty" url:"doc_url,omitempty,key"`         // documentation URL of account feature
        Enabled     *bool      `json:"enabled,omitempty" url:"enabled,omitempty,key"`         // whether or not account feature has been enabled
        ID          *string    `json:"id,omitempty" url:"id,omitempty,key"`                   // unique identifier of account feature
        Name        *string    `json:"name,omitempty" url:"name,omitempty,key"`               // unique name of account feature
        State       *string    `json:"state,omitempty" url:"state,omitempty,key"`             // state of account feature
        UpdatedAt   *time.Time `json:"updated_at,omitempty" url:"updated_at,omitempty,key"`   // when account feature was updated
}

// List existing account features.
func (s *Service) AccountFeatureList(lr *ListRange) (AccountFeatureListResult, error) {
        var accountFeature AccountFeatureListResult
        return accountFeature, s.Get(&accountFeature, fmt.Sprintf("/account/features"), nil, lr)
}
```

But I think both of those are fine and desirable, since they give names to things and are compatible with the bare types if needed.

I've created https://github.com/cyberdelia/heroku-go/pull/12 with the results of running this branch against the Heroku Platform API schema and it installs correctly as far as I can tell.

WDYT :eyes: @cyberdelia ?