### PR TITLE
Adds support for context.Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Download and install:
 $ go get -u github.com/interagent/schematic/cmd/schematic
 ```
 
-**Warning**: schematic requires Go >= 1.2.
+**Warning**: schematic requires Go >= 1.7.
 
 ## Client Generation
 

--- a/gen.go
+++ b/gen.go
@@ -41,8 +41,8 @@ func (s *Schema) Generate() ([]byte, error) {
 
 	// TODO: Check if we need time.
 	templates.ExecuteTemplate(&buf, "imports.tmpl", []string{
-		"encoding/json", "fmt", "io", "reflect",
-		"net/http", "runtime", "time", "bytes",
+		"encoding/json", "fmt", "io", "reflect", "net/http", "runtime",
+		"time", "bytes", "context",
 		"github.com/google/go-querystring/query",
 	})
 	templates.ExecuteTemplate(&buf, "service.tmpl", struct {

--- a/templates/funcs.tmpl
+++ b/templates/funcs.tmpl
@@ -10,12 +10,12 @@
   {{end}}
 
   {{asComment .Description}}
-  func (s *Service) {{printf "%s-%s" $Name .Title | initialCap}}({{params $Name .}}) ({{values $Name $Def .}}) {
+  func (s *Service) {{printf "%s-%s" $Name .Title | initialCap}}(ctx context.Context, {{params $Name .}}) ({{values $Name $Def .}}) {
     {{if ($Def.EmptyResult .)}}
-      return s.{{methodCap .Method}}(nil, fmt.Sprintf("{{.HRef}}", {{args .HRef}}){{requestParams .}})
+      return s.{{methodCap .Method}}(ctx, nil, fmt.Sprintf("{{.HRef}}", {{args .HRef}}){{requestParams .}})
     {{else}}
       {{$Var := initialLow $Name}}var {{$Var}} {{returnType $Name $Def .}}
-      return {{if ($Def.ReturnsCustomType .)}}&{{end}}{{$Var}}, s.{{methodCap .Method}}(&{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}){{requestParams .}})
+      return {{if ($Def.ReturnsCustomType .)}}&{{end}}{{$Var}}, s.{{methodCap .Method}}(ctx, &{{$Var}}, fmt.Sprintf("{{.HRef}}", {{args .HRef}}){{requestParams .}})
     {{end}}
   }
 {{end}}

--- a/templates/service.tmpl
+++ b/templates/service.tmpl
@@ -23,7 +23,7 @@ func NewService(c *http.Client) *Service {
 }
 
 // NewRequest generates an HTTP request, but does not perform the request.
-func (s *Service) NewRequest(method, path string, body interface{}, q interface{}) (*http.Request, error) {
+func (s *Service) NewRequest(ctx context.Context, method, path string, body interface{}, q interface{}) (*http.Request, error) {
 	var ctype string
 	var rbody io.Reader
 
@@ -56,6 +56,7 @@ func (s *Service) NewRequest(method, path string, body interface{}, q interface{
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	if q != nil {
 		v, err := query.Values(q)
@@ -79,8 +80,8 @@ func (s *Service) NewRequest(method, path string, body interface{}, q interface{
 }
 
 // Do sends a request and decodes the response into v.
-func (s *Service) Do(v interface{}, method, path string, body interface{}, q interface{}, lr *ListRange) error {
-	req, err := s.NewRequest(method, path, body, q)
+func (s *Service) Do(ctx context.Context, v interface{}, method, path string, body interface{}, q interface{}, lr *ListRange) error {
+	req, err := s.NewRequest(ctx, method, path, body, q)
 	if err != nil {
 		return err
 	}
@@ -103,28 +104,28 @@ func (s *Service) Do(v interface{}, method, path string, body interface{}, q int
 }
 
 // Get sends a GET request and decodes the response into v.
-func (s *Service) Get(v interface{}, path string, query interface{}, lr *ListRange) error {
-	return s.Do(v, "GET", path, nil, query, lr)
+func (s *Service) Get(ctx context.Context, v interface{}, path string, query interface{}, lr *ListRange) error {
+	return s.Do(ctx, v, "GET", path, nil, query, lr)
 }
 
 // Patch sends a Path request and decodes the response into v.
-func (s *Service) Patch(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "PATCH", path, body, nil, nil)
+func (s *Service) Patch(ctx context.Context, v interface{}, path string, body interface{}) error {
+	return s.Do(ctx, v, "PATCH", path, body, nil, nil)
 }
 
 // Post sends a POST request and decodes the response into v.
-func (s *Service) Post(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "POST", path, body, nil, nil)
+func (s *Service) Post(ctx context.Context, v interface{}, path string, body interface{}) error {
+	return s.Do(ctx, v, "POST", path, body, nil, nil)
 }
 
 // Put sends a PUT request and decodes the response into v.
-func (s *Service) Put(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "PUT", path, body, nil, nil)
+func (s *Service) Put(ctx context.Context, v interface{}, path string, body interface{}) error {
+	return s.Do(ctx, v, "PUT", path, body, nil, nil)
 }
 
 // Delete sends a DELETE request.
-func (s *Service) Delete(v interface{}, path string) error {
-	return s.Do(v, "DELETE", path, nil, nil, nil)
+func (s *Service) Delete(ctx context.Context, v interface{}, path string) error {
+	return s.Do(ctx, v, "DELETE", path, nil, nil, nil)
 }
 
 // ListRange describes a range.


### PR DESCRIPTION
The `context` package is the most official way to timeout or otherwise cancel requests in Go >= 1.7.

For some prior art from other open source clients, see [go-github](https://github.com/google/go-github/pull/529) and [go-asana](https://github.com/tambet/go-asana/pull/4).

Example of generated code:

```go
// Get sends a GET request and decodes the response into v.
func (s *Service) Get(ctx context.Context, v interface{}, path string, query interface{}, lr *ListRange) error {
        return s.Do(ctx, v, "GET", path, nil, query, lr)
}


// Info for account.
func (s *Service) AccountInfo(ctx context.Context) (*AccountInfoResult, error) {
        var account AccountInfoResult
        return &account, s.Get(ctx, &account, fmt.Sprintf("/account"), nil, nil)
}

```