### PR TITLE
Re-use existing types where easily detected

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -274,8 +274,11 @@ func (s *Schema) ReturnsCustomType(l *Link) bool {
 }
 
 // ReturnedGoType returns Go type returned by the given link as a string.
-func (s *Schema) ReturnedGoType(l *Link) string {
+func (s *Schema) ReturnedGoType(name string, l *Link) string {
 	if l.TargetSchema != nil {
+		if l.TargetSchema.Items == s {
+			return "[]" + initialCap(name)
+		}
 		return l.TargetSchema.goType(true, true)
 	}
 	return s.goType(true, true)

--- a/helpers.go
+++ b/helpers.go
@@ -202,5 +202,5 @@ func paramType(name string, l *Link) string {
 }
 
 func defineCustomType(s *Schema, l *Link) bool {
-	return l.TargetSchema != nil
+	return l.TargetSchema != nil && l.TargetSchema != s
 }

--- a/templates/funcs.tmpl
+++ b/templates/funcs.tmpl
@@ -6,7 +6,7 @@
   {{end}}
 
   {{if (defineCustomType $Def .)}}
-   type {{returnType $Name $Def .}} {{$Def.ReturnedGoType .}}
+   type {{returnType $Name $Def .}} {{$Def.ReturnedGoType $Name .}}
   {{end}}
 
   {{asComment .Description}}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -12,7 +12,7 @@ var templates = map[string]string{"field.tmpl": `{{initialCap .Name}} {{.Type}} 
   {{end}}
 
   {{if (defineCustomType $Def .)}}
-   type {{returnType $Name $Def .}} {{$Def.ReturnedGoType .}}
+   type {{returnType $Name $Def .}} {{$Def.ReturnedGoType $Name .}}
   {{end}}
 
   {{asComment .Description}}


### PR DESCRIPTION
This updates the generator to re-use existing types for links which
return the same type as their containing schema. For example:

```json
{
  "definitions": {
    "account": {
      "properties": {
        "id": { "type": "string" }
      },
      "links": [
        { "title": "Info",
          "targetSchema": { "$ref": "#/definitions/account" }
        },
        { "title": "List",
          "targetSchema": {
            "items": {
              "$ref": "#/definitions/account"
            },
            "type": "array"
          }
        }
      ]
    }
  }
}
```

Would produce:

```go
type Account { ID string }

func (*Service) Info() *Account

type AccountListResult []Account
func (*Service) List() AccountListResult
```

Links with custom target schemas, or which reference other schema
definitions, will still get assigned custom types.

As shown in the example, List methods will also each still get their
own type (`AccountListByNameResult`), but use the base type where
available.

For Heroku's platform.json, this removes 134 duplicate types from the
generated client, and reduces 56 list types to `[]T`.