### PR TITLE
Generalize ListRange as CallOption

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -323,10 +323,6 @@ func (l *Link) Parameters(name string) ([]string, map[string]string) {
 			params["o"] = "*" + params["o"]
 		}
 	}
-	if l.Rel == "instances" && strings.ToUpper(l.Method) == "GET" {
-		order = append(order, "lr")
-		params["lr"] = "*ListRange"
-	}
 	return order, params
 }
 

--- a/gen_test.go
+++ b/gen_test.go
@@ -266,8 +266,7 @@ var paramsTests = []struct {
 			Rel:    "instances",
 			Method: "get",
 		},
-		Order:      []string{"lr"},
-		Parameters: map[string]string{"lr": "*ListRange"},
+		Parameters: map[string]string{},
 	},
 	{
 		Schema: &Schema{},
@@ -351,8 +350,8 @@ var paramsTests = []struct {
 				Type: "object",
 			},
 		},
-		Order:      []string{"o", "lr"},
-		Parameters: map[string]string{"o": "map[string]string", "lr": "*ListRange"},
+		Order:      []string{"o"},
+		Parameters: map[string]string{"o": "map[string]string"},
 	},
 	{
 		Schema: &Schema{

--- a/helpers.go
+++ b/helpers.go
@@ -153,13 +153,14 @@ func params(name string, l *Link) string {
 	for _, n := range order {
 		p = append(p, fmt.Sprintf("%s %s", initialLow(n), params[n]))
 	}
+	p = append(p, "opts ...CallOption")
 	return strings.Join(p, ", ")
 }
 
 func requestParams(l *Link) string {
 	_, params := l.Parameters("")
 	if strings.ToUpper(l.Method) == "DELETE" {
-		return ""
+		return ", opts..."
 	}
 	p := []string{""}
 	if _, ok := params["o"]; ok {
@@ -167,11 +168,7 @@ func requestParams(l *Link) string {
 	} else {
 		p = append(p, "nil")
 	}
-	if _, ok := params["lr"]; ok {
-		p = append(p, "lr")
-	} else if strings.ToUpper(l.Method) == "GET" {
-		p = append(p, "nil")
-	}
+	p = append(p, "opts...")
 	return strings.Join(p, ", ")
 }
 

--- a/templates/service.tmpl
+++ b/templates/service.tmpl
@@ -80,13 +80,13 @@ func (s *Service) NewRequest(ctx context.Context, method, path string, body inte
 }
 
 // Do sends a request and decodes the response into v.
-func (s *Service) Do(ctx context.Context, v interface{}, method, path string, body interface{}, q interface{}, lr *ListRange) error {
+func (s *Service) Do(ctx context.Context, v interface{}, method, path string, body interface{}, q interface{}, opts ...CallOption) error {
 	req, err := s.NewRequest(ctx, method, path, body, q)
 	if err != nil {
 		return err
 	}
-	if lr != nil {
-		lr.SetHeader(req)
+	for _, opt := range opts {
+		opt.Apply(req)
 	}
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -104,28 +104,33 @@ func (s *Service) Do(ctx context.Context, v interface{}, method, path string, bo
 }
 
 // Get sends a GET request and decodes the response into v.
-func (s *Service) Get(ctx context.Context, v interface{}, path string, query interface{}, lr *ListRange) error {
-	return s.Do(ctx, v, "GET", path, nil, query, lr)
+func (s *Service) Get(ctx context.Context, v interface{}, path string, query interface{}, opts ...CallOption) error {
+	return s.Do(ctx, v, "GET", path, nil, query, opts...)
 }
 
 // Patch sends a Path request and decodes the response into v.
-func (s *Service) Patch(ctx context.Context, v interface{}, path string, body interface{}) error {
-	return s.Do(ctx, v, "PATCH", path, body, nil, nil)
+func (s *Service) Patch(ctx context.Context, v interface{}, path string, body interface{}, opts ...CallOption) error {
+	return s.Do(ctx, v, "PATCH", path, body, nil, opts...)
 }
 
 // Post sends a POST request and decodes the response into v.
-func (s *Service) Post(ctx context.Context, v interface{}, path string, body interface{}) error {
-	return s.Do(ctx, v, "POST", path, body, nil, nil)
+func (s *Service) Post(ctx context.Context, v interface{}, path string, body interface{}, opts ...CallOption) error {
+	return s.Do(ctx, v, "POST", path, body, nil, opts...)
 }
 
 // Put sends a PUT request and decodes the response into v.
-func (s *Service) Put(ctx context.Context, v interface{}, path string, body interface{}) error {
-	return s.Do(ctx, v, "PUT", path, body, nil, nil)
+func (s *Service) Put(ctx context.Context, v interface{}, path string, body interface{}, opts ...CallOption) error {
+	return s.Do(ctx, v, "PUT", path, body, nil, opts...)
 }
 
 // Delete sends a DELETE request.
-func (s *Service) Delete(ctx context.Context, v interface{}, path string) error {
-	return s.Do(ctx, v, "DELETE", path, nil, nil, nil)
+func (s *Service) Delete(ctx context.Context, v interface{}, path string, opts ...CallOption) error {
+	return s.Do(ctx, v, "DELETE", path, nil, nil, opts...)
+}
+
+// CallOption configures an HTTP request before it is executed.
+type CallOption interface {
+	Apply(*http.Request)
 }
 
 // ListRange describes a range.
@@ -137,8 +142,10 @@ type ListRange struct {
 	LastID     string
 }
 
-// SetHeader set headers on the given Request.
-func (lr *ListRange) SetHeader(req *http.Request) {
+// Apply set headers on the given Request.
+//
+// Apply implements the CallOption interface.
+func (lr *ListRange) Apply(req *http.Request) {
 	var hdrval string
 	if lr.Field != "" {
 		hdrval += lr.Field + " "

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -132,13 +132,13 @@ func (s *Service) NewRequest(ctx context.Context, method, path string, body inte
 }
 
 // Do sends a request and decodes the response into v.
-func (s *Service) Do(ctx context.Context, v interface{}, method, path string, body interface{}, q interface{}, lr *ListRange) error {
+func (s *Service) Do(ctx context.Context, v interface{}, method, path string, body interface{}, q interface{}, opts ...CallOption) error {
 	req, err := s.NewRequest(ctx, method, path, body, q)
 	if err != nil {
 		return err
 	}
-	if lr != nil {
-		lr.SetHeader(req)
+	for _, opt := range opts {
+		opt.Apply(req)
 	}
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -156,28 +156,33 @@ func (s *Service) Do(ctx context.Context, v interface{}, method, path string, bo
 }
 
 // Get sends a GET request and decodes the response into v.
-func (s *Service) Get(ctx context.Context, v interface{}, path string, query interface{}, lr *ListRange) error {
-	return s.Do(ctx, v, "GET", path, nil, query, lr)
+func (s *Service) Get(ctx context.Context, v interface{}, path string, query interface{}, opts ...CallOption) error {
+	return s.Do(ctx, v, "GET", path, nil, query, opts...)
 }
 
 // Patch sends a Path request and decodes the response into v.
-func (s *Service) Patch(ctx context.Context, v interface{}, path string, body interface{}) error {
-	return s.Do(ctx, v, "PATCH", path, body, nil, nil)
+func (s *Service) Patch(ctx context.Context, v interface{}, path string, body interface{}, opts ...CallOption) error {
+	return s.Do(ctx, v, "PATCH", path, body, nil, opts...)
 }
 
 // Post sends a POST request and decodes the response into v.
-func (s *Service) Post(ctx context.Context, v interface{}, path string, body interface{}) error {
-	return s.Do(ctx, v, "POST", path, body, nil, nil)
+func (s *Service) Post(ctx context.Context, v interface{}, path string, body interface{}, opts ...CallOption) error {
+	return s.Do(ctx, v, "POST", path, body, nil, opts...)
 }
 
 // Put sends a PUT request and decodes the response into v.
-func (s *Service) Put(ctx context.Context, v interface{}, path string, body interface{}) error {
-	return s.Do(ctx, v, "PUT", path, body, nil, nil)
+func (s *Service) Put(ctx context.Context, v interface{}, path string, body interface{}, opts ...CallOption) error {
+	return s.Do(ctx, v, "PUT", path, body, nil, opts...)
 }
 
 // Delete sends a DELETE request.
-func (s *Service) Delete(ctx context.Context, v interface{}, path string) error {
-	return s.Do(ctx, v, "DELETE", path, nil, nil, nil)
+func (s *Service) Delete(ctx context.Context, v interface{}, path string, opts ...CallOption) error {
+	return s.Do(ctx, v, "DELETE", path, nil, nil, opts...)
+}
+
+// CallOption configures an HTTP request before it is executed.
+type CallOption interface {
+	Apply(*http.Request)
 }
 
 // ListRange describes a range.
@@ -189,8 +194,10 @@ type ListRange struct {
 	LastID     string
 }
 
-// SetHeader set headers on the given Request.
-func (lr *ListRange) SetHeader(req *http.Request) {
+// Apply set headers on the given Request.
+//
+// Apply implements the CallOption interface.
+func (lr *ListRange) Apply(req *http.Request) {
 	var hdrval string
 	if lr.Field != "" {
 		hdrval += lr.Field + " "


### PR DESCRIPTION
Generated clients used to require a `*ListRange` for all `List` calls,
with some special handling for the case where the range was nil.

Additionally, consumers were unable to configure outgoing requests
except through a custom `http.Transport` applied to all requests.

This PR introduces a `CallOption` interface for manipulating HTTP
requests generated by the service, and accepted by all methods.

`ListRange` is a builtin `CallOption` for usage with list methods:

```go
apps, err := client.AppList()
appsByAccount, err := client.AppList(&ListRange{Field: "account"})
```

Client packages or end-users can further augment requests, for example,
setting special headers for 2FA, by defining their own types that
implement `CallOption`:

```go
// Header returns a CallOption that will set the provided header
// for executed requests.
func Header(key, value string) CallOption {
	return callOptionFunc(func(req *http.Request) {
		req.Header.Set(key, value)
	})
}

type callOptionFunc func(*http.Request)

func (f callOptionFunc) Apply(req *http.Request) { f(req) }
```

The naming and general pattern is inspired by [gRPC](https://godoc.org/google.golang.org/grpc#CallOption) and [Google's own client generator](https://godoc.org/google.golang.org/api/storage/v1#BucketAccessControlsGetCall.Do).