### PR TITLE
Fix Range header formatting

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -42,7 +42,7 @@ func (s *Schema) Generate() ([]byte, error) {
 	// TODO: Check if we need time.
 	templates.ExecuteTemplate(&buf, "imports.tmpl", []string{
 		"encoding/json", "fmt", "io", "reflect", "net/http", "runtime",
-		"time", "bytes", "context",
+		"time", "bytes", "context", "strings",
 		"github.com/google/go-querystring/query",
 	})
 	templates.ExecuteTemplate(&buf, "service.tmpl", struct {

--- a/templates/service.tmpl
+++ b/templates/service.tmpl
@@ -144,15 +144,16 @@ func (lr *ListRange) SetHeader(req *http.Request) {
 		hdrval += lr.Field + " "
 	}
 	hdrval += lr.FirstID + ".." + lr.LastID
-	if lr.Max != 0 {
-		hdrval += fmt.Sprintf("; max=%d", lr.Max)
-		if lr.Descending {
-			hdrval += "; "
-		}
-	}
 
+	params := make([]string, 0, 2)
+	if lr.Max != 0 {
+		params = append(params, fmt.Sprintf("max=%d", lr.Max))
+	}
 	if lr.Descending {
-		hdrval += "order=desc"
+		params = append(params, "order=desc")
+	}
+	if len(params) > 0 {
+		hdrval += fmt.Sprintf("; %s", strings.Join(params, ","))
 	}
 
 	req.Header.Set("Range", hdrval)

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -196,15 +196,16 @@ func (lr *ListRange) SetHeader(req *http.Request) {
 		hdrval += lr.Field + " "
 	}
 	hdrval += lr.FirstID + ".." + lr.LastID
-	if lr.Max != 0 {
-		hdrval += fmt.Sprintf("; max=%d", lr.Max)
-		if lr.Descending {
-			hdrval += "; "
-		}
-	}
 
+	params := make([]string, 0, 2)
+	if lr.Max != 0 {
+		params = append(params, fmt.Sprintf("max=%d", lr.Max))
+	}
 	if lr.Descending {
-		hdrval += "order=desc"
+		params = append(params, "order=desc")
+	}
+	if len(params) > 0 {
+		hdrval += fmt.Sprintf("; %s", strings.Join(params, ","))
 	}
 
 	req.Header.Set("Range", hdrval)


### PR DESCRIPTION
Previously there was an edge case in Range header formatting that cased
`ListRange` structs that set both `Field` and `Descending` but not `Max`
to be rendered without a semicolon separator before parameters:

    version ..order=desc

After this commit the correct header is rendered for all combinations of
struct values:

    version ..; order=desc