### PR TITLE
Disallow duplicate link titles

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Blake Gentry <b@heroku.com>
 Bo Jeans <bo@heroku.com>
 Timothée Peignier <tim@heroku.com>
+Chris Johnson <cjohnson@heroku.com>

--- a/gen.go
+++ b/gen.go
@@ -71,7 +71,7 @@ func (s *Schema) Generate() ([]byte, error) {
 		}
 
 		if !s.CheckForDuplicateTitles() {
-			panic(fmt.Errorf("duplicate titles detected for %s", context.Name))
+			return nil, fmt.Errorf("duplicate titles detected for %s", context.Name)
 		}
 
 		templates.ExecuteTemplate(&buf, "struct.tmpl", context)

--- a/gen.go
+++ b/gen.go
@@ -70,7 +70,7 @@ func (s *Schema) Generate() ([]byte, error) {
 			Definition: schema,
 		}
 
-		if !s.checkForDuplicateTitles() {
+		if !s.CheckForDuplicateTitles() {
 			panic(fmt.Errorf("duplicate titles detected for %s", context.Name))
 		}
 
@@ -241,23 +241,24 @@ func (s *Schema) Values(name string, l *Link) []string {
 	return values
 }
 
-// checkForDuplicateTitles ensures that all titles are unique for a schema.
+// CheckForDuplicateTitles ensures that all titles are unique for a schema.
 //
 // If more than one link in a given schema has the same title, we cannot
 // accurately generate the client from the schema. Although it's not strictly a
 // schema violation, it needs to be fixed before the client can be properly
 // generated.
-func (s *Schema) checkForDuplicateTitles() bool {
+func (s *Schema) CheckForDuplicateTitles() bool {
 	titles := map[string]bool{}
 	var uniqueLinks []*Link
 	for _, link := range s.Links {
-		if _, ok := titles[link.Title]; !ok {
+		title := strings.ToLower(link.Title)
+		if _, ok := titles[title]; !ok {
 			uniqueLinks = append(uniqueLinks, link)
 		}
-		titles[link.Title] = true
+		titles[title] = true
 	}
 
-	return len(uniqueLinks) == len(s.Links)
+	return len(uniqueLinks) != len(s.Links)
 }
 
 // URL returns schema base URL.

--- a/gen_test.go
+++ b/gen_test.go
@@ -616,3 +616,63 @@ func TestValues(t *testing.T) {
 		}
 	}
 }
+
+var linkTitleTests = []struct {
+	Schema   *Schema
+	Expected bool
+}{
+	{
+		Schema: &Schema{
+			Title: "Selfreferencing",
+			Type:  "object",
+			Links: []*Link{
+				{
+					Title: "Create",
+				},
+				{
+					Title: "Create",
+				},
+			},
+		},
+		Expected: true,
+	},
+	{
+		Schema: &Schema{
+			Title: "Selfreferencing",
+			Type:  "object",
+			Links: []*Link{
+				{
+					Title: "update",
+				},
+				{
+					Title: "Update",
+				},
+			},
+		},
+		Expected: true,
+	},
+	{
+		Schema: &Schema{
+			Title: "Selfreferencing",
+			Type:  "object",
+			Links: []*Link{
+				{
+					Title: "Create",
+				},
+				{
+					Title: "Delete",
+				},
+			},
+		},
+		Expected: false,
+	},
+}
+
+func TestLinkTitles(t *testing.T) {
+	for i, lt := range linkTitleTests {
+		resp := lt.Schema.CheckForDuplicateTitles()
+		if resp != lt.Expected {
+			t.Errorf("%d: wants %v, got %v", i, lt.Expected, resp)
+		}
+	}
+}

--- a/templates/funcs.tmpl
+++ b/templates/funcs.tmpl
@@ -1,6 +1,6 @@
 {{$Name := .Name}}
 {{$Def := .Definition}}
-{{range .Definition.UniqueLinks}}
+{{range .Definition.Links}}
   {{if .AcceptsCustomType}}
    type {{paramType $Name .}} {{linkGoType .}}
   {{end}}
@@ -19,4 +19,3 @@
     {{end}}
   }
 {{end}}
-

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -6,7 +6,7 @@ var templates = map[string]string{"field.tmpl": `{{initialCap .Name}} {{.Type}} 
 `,
 	"funcs.tmpl": `{{$Name := .Name}}
 {{$Def := .Definition}}
-{{range .Definition.UniqueLinks}}
+{{range .Definition.Links}}
   {{if .AcceptsCustomType}}
    type {{paramType $Name .}} {{linkGoType .}}
   {{end}}
@@ -263,4 +263,3 @@ func Parse(t *template.Template) (*template.Template, error) {
 	}
 	return t, nil
 }
-


### PR DESCRIPTION
https://github.com/interagent/schematic/issues/45

Dropping numerous client API calls as a part of client generation is probably an incorrect approach, both here in schematic and in the ruby version of this tool, Heroics.

While a number of PRs have been initiated to fix the underlying heroku platform api schema itself, I believe these two tools should raise an error and should not generate an incomplete client in the event of duplicate link titles.

This PR replaces the code that was dropping the duplicate links with a method that checks for dups and panics if any are found.

During the discussion here (https://github.com/heroku/api/pull/7787#issuecomment-299169974) we are attempting to do the following:
- fix all of the (sub)schemas of the platform API.
- update schematic (this PR) and heroics to throw an error when duplicates are found.
- regenerate the Golang and ruby clients, incrementing the major version in order to reflect the breaking changes (title changes -> method name changes) that will be introduced.

