### PR TITLE
Fix condision for error when duplicate link titles

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -70,7 +70,7 @@ func (s *Schema) Generate() ([]byte, error) {
 			Definition: schema,
 		}
 
-		if s.CheckForDuplicateTitles() {
+		if !s.AreTitleLinksUnique() {
 			return nil, fmt.Errorf("duplicate titles detected for %s", context.Name)
 		}
 
@@ -241,13 +241,13 @@ func (s *Schema) Values(name string, l *Link) []string {
 	return values
 }
 
-// CheckForDuplicateTitles ensures that all titles are unique for a schema.
+// AreTitleLinksUnique ensures that all titles are unique for a schema.
 //
 // If more than one link in a given schema has the same title, we cannot
 // accurately generate the client from the schema. Although it's not strictly a
 // schema violation, it needs to be fixed before the client can be properly
 // generated.
-func (s *Schema) CheckForDuplicateTitles() bool {
+func (s *Schema) AreTitleLinksUnique() bool {
 	titles := map[string]bool{}
 	var uniqueLinks []*Link
 	for _, link := range s.Links {
@@ -258,7 +258,7 @@ func (s *Schema) CheckForDuplicateTitles() bool {
 		titles[title] = true
 	}
 
-	return len(uniqueLinks) != len(s.Links)
+	return len(uniqueLinks) == len(s.Links)
 }
 
 // URL returns schema base URL.

--- a/gen.go
+++ b/gen.go
@@ -70,7 +70,7 @@ func (s *Schema) Generate() ([]byte, error) {
 			Definition: schema,
 		}
 
-		if !s.CheckForDuplicateTitles() {
+		if s.CheckForDuplicateTitles() {
 			return nil, fmt.Errorf("duplicate titles detected for %s", context.Name)
 		}
 

--- a/gen_test.go
+++ b/gen_test.go
@@ -634,7 +634,7 @@ var linkTitleTests = []struct {
 				},
 			},
 		},
-		Expected: true,
+		Expected: false,
 	},
 	{
 		Schema: &Schema{
@@ -649,7 +649,7 @@ var linkTitleTests = []struct {
 				},
 			},
 		},
-		Expected: true,
+		Expected: false,
 	},
 	{
 		Schema: &Schema{
@@ -664,13 +664,13 @@ var linkTitleTests = []struct {
 				},
 			},
 		},
-		Expected: false,
+		Expected: true,
 	},
 }
 
 func TestLinkTitles(t *testing.T) {
 	for i, lt := range linkTitleTests {
-		resp := lt.Schema.CheckForDuplicateTitles()
+		resp := lt.Schema.AreTitleLinksUnique()
 		if resp != lt.Expected {
 			t.Errorf("%d: wants %v, got %v", i, lt.Expected, resp)
 		}


### PR DESCRIPTION
`CheckForDuplicateTitles()` returns true if there are duplicates.
Therefore, if it is not duplicated, an error occurred.
