### PR TITLE
Test title uniqueness on the sub-schema, not the top level schema

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -70,7 +70,7 @@ func (s *Schema) Generate() ([]byte, error) {
 			Definition: schema,
 		}
 
-		if !s.AreTitleLinksUnique() {
+		if !context.Definition.AreTitleLinksUnique() {
 			return nil, fmt.Errorf("duplicate titles detected for %s", context.Name)
 		}
 


### PR DESCRIPTION
It looks like we were mistakenly testing for title uniqueness on `s`--the top-level schema--within every loop iteration, instead of `schema` (same as `context.Definition` which I used to hopefully increase clarity)