### PR TITLE
Don't need pointers to have nilable interface, string or map.

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -222,7 +222,10 @@ func (s *Schema) goType(required bool, force bool) (goType string) {
 	}
 	// Types allow null
 	if contains("null", types) || !(required || force) {
-		return "*" + goType
+		// Don't need a pointer for these types to be "nilable"
+		if goType != "interface{}" && !strings.HasPrefix(goType, "[]") && !strings.HasPrefix(goType, "map[") {
+			return "*" + goType
+		}
 	}
 	return goType
 }

--- a/gen_test.go
+++ b/gen_test.go
@@ -192,6 +192,21 @@ var typeTests = []struct {
 		},
 		Type: "*time.Time",
 	},
+	{
+		Schema: &Schema{
+			Type: []interface{}{"null", "array"},
+			Items: &Schema{
+				Type: "string",
+			},
+		},
+		Type: "[]string",
+	},
+	{
+		Schema: &Schema{
+			Type: "any",
+		},
+		Type: "interface{}",
+	},
 }
 
 func TestSchemaType(t *testing.T) {


### PR DESCRIPTION
This types can be nilable, so don't need the additional indirection
to differ between empty and nil.