### PR TITLE
Fail on schema problems with context

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -377,7 +377,8 @@ func (l *Link) GoType() (string, bool) {
 func fail(v interface{}, err error) {
 	el, _ := json.MarshalIndent(v, "    ", "  ")
 
-	fmt.Printf(
+	fmt.Fprintf(
+		os.Stderr,
 		"Error processing schema element:\n    %s\n\nFailed with: %s\n",
 		el,
 		err,


### PR DESCRIPTION
There are currently a few places where an error causes schematic to exit
with an error with no context to resolve the problem:

    schematic: unknown type <nil>

This updates the places where we exit on schema problems to also print
the schema that was being processed.

Now these cases will fail with better context:

```
> schematic tmp/schema.json
Error processing schema element:
    {
      "description": "the pipeline which owns this test-run",
      "properties": {
        "id": {
          "description": "unique identifier of pipeline",
          "readOnly": true,
          "example": "01234567-89ab-cdef-0123-456789abcdef",
          "format": "uuid",
          "type": [
            "string"
          ]
        }
      }
    }

Failed with: unknown type <nil>
```

It does not add this context for `Link`, which is the other case where we panic on an error, because attempting to marshal the Link with a missing HRef introduces an infinite loop.