### PR TITLE
Improve error message for "duplicate titles detected"

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -75,7 +75,7 @@ func (s *Schema) Generate() ([]byte, error) {
 		}
 
 		if !context.Definition.AreTitleLinksUnique() {
-			return nil, fmt.Errorf("duplicate titles detected for %s", context.Name)
+			return nil, fmt.Errorf("Duplicate %s.links.title detected in the schema. Links must have distinct titles.", context.Name)
 		}
 
 		templates.ExecuteTemplate(&buf, "struct.tmpl", context)


### PR DESCRIPTION
I encountered this error, and had to dig into schematic source code to understand what it meant.

This PR corrects the error message to be clear & actionable.