### PR TITLE
Improve error messages

### DIFF
--- a/cmd/schematic/schematic.go
+++ b/cmd/schematic/schematic.go
@@ -65,13 +65,13 @@ func main() {
 	var s schematic.Schema
 	d := json.NewDecoder(i)
 	if err := d.Decode(&s); err != nil {
-		log.Fatal(err)
+		log.Fatal(fmt.Errorf("Error decoding schema JSON: %w", err))
 	}
 
 	code, err := s.Generate()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", code)
-		log.Fatal(err)
+		log.Fatal(fmt.Errorf("Error generating Go code (output above): %w", err))
 	}
 
 	fmt.Fprintln(o, string(code))

--- a/gen.go
+++ b/gen.go
@@ -75,7 +75,7 @@ func (s *Schema) Generate() ([]byte, error) {
 		}
 
 		if !context.Definition.AreTitleLinksUnique() {
-			return nil, fmt.Errorf("duplicate titles detected for %s", context.Name)
+			return nil, fmt.Errorf("Duplicate %s.links.title detected in the schema. Links must have distinct titles.", context.Name)
 		}
 
 		templates.ExecuteTemplate(&buf, "struct.tmpl", context)
@@ -88,7 +88,7 @@ func (s *Schema) Generate() ([]byte, error) {
 	// Format sources
 	clean, err := format.Source(bytes)
 	if err != nil {
-		return buf.Bytes(), err
+		return bytes, fmt.Errorf("Error formatting Go source: %w", err)
 	}
 	return clean, nil
 }


### PR DESCRIPTION
* give error messages context of where they occur
* output the generated code to align with the error line numbers output from the code formatter.